### PR TITLE
pop unmarshalled type on exception

### DIFF
--- a/xstream/src/java/com/thoughtworks/xstream/core/TreeUnmarshaller.java
+++ b/xstream/src/java/com/thoughtworks/xstream/core/TreeUnmarshaller.java
@@ -70,7 +70,6 @@ public class TreeUnmarshaller implements UnmarshallingContext {
         try {
             types.push(type);
             Object result = converter.unmarshal(reader, this);
-            types.popSilently();
             return result;
         } catch (ConversionException conversionException) {
             addInformationTo(conversionException, type, converter, parent);
@@ -79,6 +78,9 @@ public class TreeUnmarshaller implements UnmarshallingContext {
             ConversionException conversionException = new ConversionException(e);
             addInformationTo(conversionException, type, converter, parent);
             throw conversionException;
+        }
+        finally {
+            types.popSilently();
         }
     }
 


### PR DESCRIPTION
bugfix for the following scenario: 

deserializing the following xml from jenkins:
```
<matrix-project plugin="matrix-project@1.9-SNAPSHOT">
  <publishers>
    <htmlpublisher.HtmlPublisher plugin="htmlpublisher@1.12">
    </htmlpublisher.HtmlPublisher>
    <hudson.plugins.performance.PerformancePublisher plugin="performance@1.16">
    </hudson.plugins.performance.PerformancePublisher>
  </publishers>
</matrix-project>
```

* start deserializing hudson.util.DescribableList (publishers)
  * push DescribableList on TreeUnmarshaller.types
  * DescribableList$ConverterImpl tries to collects the children into a list and creates the real DescribableList instance after
* deserialize HtmlPublisher
* start deserializing PerformancePublisher
  * push PerformancePublisher on TreeUnmarshaller.types
  * deserializing PerformancePublisher fails, but PerformancePublisher is not removed from TreeUnmarshaller.types
* DescribableList$ConverterImpl tries to create DescribableList using `(DescribableList)context.getRequiredType().newInstance()` which tries to `new PerformancePublisher()`